### PR TITLE
Made all error dialogs use Granite.MessageDialog

### DIFF
--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -506,10 +506,13 @@ namespace Screenshot {
                 if (win != null) {
                     grab_save (win, redact);
                 } else {
-                    Gtk.MessageDialog dialog = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR,
-                                                                    Gtk.ButtonsType.CLOSE, _("Could not capture screenshot"));
-                    dialog.secondary_text = _("Couldn't find an active window");
-                    dialog.deletable = false;
+                    var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                         _("Could not capture screenshot"),
+                         _("Couldn't find an active window"),
+                         "dialog-error",
+                         Gtk.ButtonsType.CLOSE
+                    );
+
                     dialog.run ();
                     dialog.destroy ();
 
@@ -561,10 +564,13 @@ namespace Screenshot {
         }
 
         private void show_error_dialog () {
-            var dialog = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR,
-                                                Gtk.ButtonsType.CLOSE, _("Could not capture screenshot"));
-            dialog.secondary_text = _("Image not saved");
-            dialog.deletable = false;
+            var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                 _("Could not capture screenshot"),
+                 _("Image not saved"),
+                 "dialog-error",
+                 Gtk.ButtonsType.CLOSE
+            );
+
             dialog.run ();
             dialog.destroy ();
         }


### PR DESCRIPTION
Made all error dialogs use the Granite.MessageDialog widget instead.
Fix for issue #99.

Looks like this now:
![screenshot from 2018-09-28 09 09 07](https://user-images.githubusercontent.com/4886639/46207562-34e98100-c2fe-11e8-9269-13d52f1b3eca.png)
