### PR TITLE
ScreenshotWindow: Increase minimum timeout to 300

### DIFF
--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -445,8 +445,8 @@ namespace Screenshot {
                 timeout -= 1000;
             }
 
-            if (timeout < 100) {
-                timeout = 100;
+            if (timeout < 300) {
+                timeout = 300;
             }
 
             return timeout;


### PR DESCRIPTION
Fixes #50 

Gala's close window animation is 195, so setting the minimum timeout amount to 300 should be plenty of time for the animation to complete