### PR TITLE
Fix update the delay variable at startup

### DIFF
--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -185,6 +185,7 @@ namespace Screenshot {
             delay_spin.value_changed.connect (() => {
                 delay = delay_spin.get_value_as_int ();
             });
+            delay = delay_spin.get_value_as_int ();
 
             take_btn.clicked.connect (take_clicked);
             close_btn.clicked.connect (close_clicked);


### PR DESCRIPTION
The spinner will show the correct stored value, but when you take a screenshot the delay will depend on the delay variable which will be zero.