### PR TITLE
ScreenshotWindow: Move from_cmd constructor to top

### DIFF
--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -45,6 +45,27 @@ namespace Screenshot {
             to_clipboard = false;
         }
 
+        public ScreenshotWindow.from_cmd (int action, int delay, bool grab_pointer, bool redact, bool clipboard) {
+            close_on_save = true;
+            from_command = true;
+            mouse_pointer = grab_pointer;
+            this.delay = int.max (0, delay);
+            this.redact = redact;
+            to_clipboard = clipboard;
+
+            switch (action) {
+                case 1:
+                    capture_mode = CaptureType.SCREEN;
+                    break;
+                case 2:
+                    capture_mode = CaptureType.CURRENT_WINDOW;
+                    break;
+                case 3:
+                    capture_mode = CaptureType.AREA;
+                    break;
+            }
+        }
+
         construct {
             if (from_command) {
                 return;
@@ -194,41 +215,6 @@ namespace Screenshot {
 
             take_btn.clicked.connect (take_clicked);
             close_btn.clicked.connect (close_clicked);
-        }
-
-        public ScreenshotWindow.from_cmd (int? action, int? delay, bool? grab_pointer, bool? redact, bool? clipboard) {
-            if (delay != null) {
-                this.delay = int.max (0, delay);
-            }
-
-            if (grab_pointer != null) {
-                mouse_pointer = grab_pointer;
-            }
-
-            if (redact != null) {
-                this.redact = redact;
-            }
-
-            if (action != null) {
-                switch (action) {
-                    case 1:
-                        capture_mode = CaptureType.SCREEN;
-                        break;
-                    case 2:
-                        capture_mode = CaptureType.CURRENT_WINDOW;
-                        break;
-                    case 3:
-                        capture_mode = CaptureType.AREA;
-                        break;
-                }
-            }
-
-            if (clipboard != null) {
-                to_clipboard = clipboard;
-            }
-
-            close_on_save = true;
-            from_command = true;
         }
 
         private void update_pointer_switch () {

--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -220,12 +220,6 @@ public class Screenshot.ScreenshotWindow : Gtk.ApplicationWindow {
         pointer_switch.sensitive = sensitive;
     }
 
-    private void update_pointer_switch () {
-        var sensitive = backend.can_screenshot_area_with_cursor || capture_mode != CaptureType.AREA;
-        pointer_label.sensitive = sensitive;
-        pointer_switch.sensitive = sensitive;
-    }
-
     private void save_file (string file_name, string format, owned string folder_dir, Gdk.Pixbuf screenshot) throws GLib.Error {
         string full_file_name = "";
         string folder_from_settings = "";


### PR DESCRIPTION
Not sure why these args were nullable since we always set all of them and they all have default values in `Application`