### PR TITLE
Adds drag support for the preview image in Save dialog

### DIFF
--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -65,16 +65,8 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         preview.gicon = pixbuf.scale_simple (width * scale, height * scale, Gdk.InterpType.BILINEAR);
         preview.get_style_context ().set_scale (1);
 
-        var preview_box = new Gtk.Grid ();
-        preview_box.halign = Gtk.Align.CENTER;
-        preview_box.add (preview);
-
-        unowned Gtk.StyleContext preview_box_context = preview_box.get_style_context ();
-        preview_box_context.add_class (Granite.STYLE_CLASS_CARD);
-        preview_box_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
-
         var preview_event_box = new Gtk.EventBox ();
-        preview_event_box.add (preview_box);
+        preview_event_box.add (preview);
 
         Gtk.drag_source_set (preview_event_box, Gdk.ModifierType.BUTTON1_MASK, null, Gdk.DragAction.COPY);
         Gtk.drag_source_add_image_targets (preview_event_box);
@@ -82,6 +74,15 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         preview_event_box.drag_data_get.connect ((widget, context, selection_data, info, time_) => {
             selection_data.set_pixbuf (pixbuf);
         });
+
+
+        var preview_box = new Gtk.Grid ();
+        preview_box.halign = Gtk.Align.CENTER;
+        preview_box.add (preview_event_box);
+
+        unowned Gtk.StyleContext preview_box_context = preview_box.get_style_context ();
+        preview_box_context.add_class (Granite.STYLE_CLASS_CARD);
+        preview_box_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
 
         var dialog_label = new Gtk.Label (_("Save Image as…"));
         dialog_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
@@ -139,7 +140,7 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         grid.margin_top = 0;
         grid.row_spacing = 12;
         grid.column_spacing = 12;
-        grid.attach (preview_event_box, 0, 0, 2, 1);
+        grid.attach (preview_box, 0, 0, 2, 1);
         grid.attach (dialog_label, 0, 1, 2, 1);
         grid.attach (name_label, 0, 2, 1, 1);
         grid.attach (name_entry, 1, 2, 1, 1);

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -73,7 +73,7 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         preview_box_context.add_class (Granite.STYLE_CLASS_CARD);
         preview_box_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
 
-        var preview_event_box = new Gtk.EventBox();
+        var preview_event_box = new Gtk.EventBox ();
         preview_event_box.add (preview_box);
 
         Gtk.drag_source_set (preview_event_box, Gdk.ModifierType.BUTTON1_MASK, null, Gdk.DragAction.COPY);

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -73,6 +73,16 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         preview_box_context.add_class (Granite.STYLE_CLASS_CARD);
         preview_box_context.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
 
+        var preview_event_box = new Gtk.EventBox();
+        preview_event_box.add (preview_box);
+
+        Gtk.drag_source_set (preview_event_box, Gdk.ModifierType.BUTTON1_MASK, null, Gdk.DragAction.COPY);
+        Gtk.drag_source_add_image_targets (preview_event_box);
+        Gtk.drag_source_set_icon_gicon (preview_event_box, preview.gicon);
+        preview_event_box.drag_data_get.connect ((widget, context, selection_data, info, time_) => {
+            selection_data.set_pixbuf (pixbuf);
+        });
+
         var dialog_label = new Gtk.Label (_("Save Image as…"));
         dialog_label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
         dialog_label.halign = Gtk.Align.START;
@@ -129,7 +139,7 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
         grid.margin_top = 0;
         grid.row_spacing = 12;
         grid.column_spacing = 12;
-        grid.attach (preview_box, 0, 0, 2, 1);
+        grid.attach (preview_event_box, 0, 0, 2, 1);
         grid.attach (dialog_label, 0, 1, 2, 1);
         grid.attach (name_label, 0, 2, 1, 1);
         grid.attach (name_entry, 1, 2, 1, 1);

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -70,7 +70,7 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
 
         Gtk.drag_source_set (preview_event_box, Gdk.ModifierType.BUTTON1_MASK, null, Gdk.DragAction.COPY);
         Gtk.drag_source_add_image_targets (preview_event_box);
-        Gtk.drag_source_set_icon_gicon (preview_event_box, new ThemedIcon("image-x-generic"));
+        Gtk.drag_source_set_icon_gicon (preview_event_box, new ThemedIcon ("image-x-generic"));
         preview_event_box.drag_data_get.connect ((widget, context, selection_data, info, time_) => {
             selection_data.set_pixbuf (pixbuf);
         });

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -78,7 +78,7 @@ public class Screenshot.SaveDialog : Gtk.Dialog {
 
         Gtk.drag_source_set (preview_event_box, Gdk.ModifierType.BUTTON1_MASK, null, Gdk.DragAction.COPY);
         Gtk.drag_source_add_image_targets (preview_event_box);
-        Gtk.drag_source_set_icon_gicon (preview_event_box, preview.gicon);
+        Gtk.drag_source_set_icon_gicon (preview_event_box, new ThemedIcon("image-x-generic"));
         preview_event_box.drag_data_get.connect ((widget, context, selection_data, info, time_) => {
             selection_data.set_pixbuf (pixbuf);
         });


### PR DESCRIPTION
Closes #29 . There are still some pending questions about the interaction:

1. should the dialog be closed after the dragging ends? 
2. this only works if the drop target supports images. As such, it does not work when dropping the image into Files or browsers. This limitation also exists with `copy to clipboard` (issue #156 )

As always, thank you for the hard work in Elementary. 

