### PR TITLE
Null terminate options array

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -46,7 +46,8 @@ public class Screenshot.Application : Gtk.Application {
         { "delay", 'd', 0, OptionArg.INT, ref delay, DELAY, SECONDS},
         { "grab-pointer", 'p', 0, OptionArg.NONE, ref grab_pointer, INCLUDE_POINTER, null },
         { "redact", 'e', 0, OptionArg.NONE, ref redact, REDACT_TEXT, null },
-        { "clipboard", 'c', 0, OptionArg.NONE, ref clipboard, CLIPBOARD, null }
+        { "clipboard", 'c', 0, OptionArg.NONE, ref clipboard, CLIPBOARD, null },
+        { null }
     };
 
     public Application () {


### PR DESCRIPTION
This is required. Not sure why it only causes crashes on some platforms, but it's not optional, so this was indeed a mistake.