### PR TITLE
Rules: Don't overwrite autoinstall

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,3 @@ override_dh_strip:
 
 override_dh_missing:
 	dh_missing --fail-missing --list-missing
-
-override_dh_auto_install:
-	dh_auto_install
-	find . -name "extra.mo" -delete


### PR DESCRIPTION
Pretty sure this is outdated since we don't install mo files in meson for extra