### PR TITLE
Create io.elementary.screenshot.install

### DIFF
--- a/debian/io.elementary.screenshot.install
+++ b/debian/io.elementary.screenshot.install
@@ -1,0 +1,6 @@
+usr/bin
+usr/share/applications
+usr/share/glib-2.0
+usr/share/icons/hicolor
+usr/share/locale
+usr/share/metainfo


### PR DESCRIPTION
Build is failing because we didn't say which things go in which package, I think

https://launchpadlibrarian.net/493029292/buildlog_ubuntu-focal-amd64.io.elementary.screenshot_1.7.1+r700-0+pkg23~daily~ubuntu6.0.1_BUILDING.txt.gz