### PR TITLE
Add launchable tag to appdata

### DIFF
--- a/data/screenshot.appdata.xml.in
+++ b/data/screenshot.appdata.xml.in
@@ -2,6 +2,7 @@
 <!-- Copyright 2015-2017 elementary, LLC <contact@elementary.io> -->
 <component type="desktop">
   <id>io.elementary.screenshot</id>
+  <launchable type="desktop-id">io.elementary.screenshot.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_group>elementary</project_group>
   <project_license>GPL-3.0+</project_license>


### PR DESCRIPTION
This is needed for appstream-generator to find the associated desktop file.

See also:
- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
- https://github.com/ximion/appstream-generator/issues/88