### PR TITLE
i18n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,15 @@ icon_res = gnome.compile_resources(
     source_dir: 'data'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 executable(
     meson.project_name(),
     icon_res,
@@ -28,6 +37,7 @@ executable(
     'src/ScreenshotProxy.vala',
     'src/ScreenshotWindow.vala',
     'src/Widgets/SaveDialog.vala',
+    config_file,
     dependencies: [
         dependency('gdk-pixbuf-2.0'),
         dependency('glib-2.0'),

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -58,6 +58,11 @@ public class Screenshot.Application : Gtk.Application {
     }
 
     construct {
+        Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (GETTEXT_PACKAGE);
+
         add_main_option_entries (OPTION_ENTRIES);
     }
 

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Allows to use the translations in Flatpak