### PR TITLE
Debian package: Remove libcanberra

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: elementary, Inc. <builds@elementary.io> 
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
-               libcanberra-dev,
                libgranite-dev,
                libgtk-3-dev (>= 3.10),
                libgdk-pixbuf2.0-dev,


### PR DESCRIPTION
We currently rely on Screenshot to play the shutter sound. This means that it needs pulseaudio permissions in Flatpak and depending on the app taking the screenshot you might not get a sound when a screenshot is taken.

In addition, no sound was played when a screenshot was copied directly to the clipboard.

Play the shutter sound in Gala to avoid this problems.

**This PR:** Remove libcanberra from the Debian package dependencies.

Fix https://github.com/elementary/gala/issues/944
Needs https://github.com/elementary/screenshot/pull/216
Needs https://github.com/elementary/gala/pull/1171