### PR TITLE
Don't play shutter sound, rely on Gala

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 You'll need the following dependencies:
 
 * meson >= 0.43.0
-* libcanberra-dev
 * libgdk-pixbuf2.0-dev
 * libgranite-dev >= 6.0.0
 * libhandy-1 >= 0.83.0

--- a/io.elementary.screenshot.yml
+++ b/io.elementary.screenshot.yml
@@ -11,26 +11,11 @@ finish-args:
   # needed for perfers-color-scheme
   - '--system-talk-name=org.freedesktop.Accounts'
 
-  # Needed for shutter sound
-  - '--socket=pulseaudio'
-
   - '--filesystem=home'
   - '--talk-name=org.gnome.Shell.Screenshot'
 
   - '--metadata=X-DConf=migrate-path=/io/elementary/screenshot/'
 modules:
-  - name: canberra
-    config-opts:
-      - '--enable-gstreamer'
-      - '--enable-pulse'
-      - '--disable-oss'
-      - '--disable-static'
-      - '--with-builtin=dso'
-    sources:
-      - type: git
-        url: http://git.0pointer.net/clone/libcanberra.git
-        disable-shallow-clone: true
-
   - name: screenshot
     buildsystem: meson
     sources:

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,6 @@ executable(
         dependency('gobject-2.0'),
         dependency('gtk+-3.0'),
         dependency('granite', version: '>=6.0.0'),
-        dependency('libcanberra'),
         dependency('libhandy-1', version: '>=0.83.0'),
         meson.get_compiler('vala').find_library('posix'),
     ],

--- a/src/ScreenshotBackend.vala
+++ b/src/ScreenshotBackend.vala
@@ -144,8 +144,6 @@ namespace Screenshot {
                 return null;
             }
 
-            play_shutter_sound ("screen-capture", _("Screenshot taken"));
-
             var file = File.new_for_path (filename_used);
             var stream = yield file.read_async ();
             var pixbuf = yield new Gdk.Pixbuf.from_stream_async (stream);
@@ -153,20 +151,6 @@ namespace Screenshot {
             yield file.delete_async ();
 
             return pixbuf;
-        }
-
-        private void play_shutter_sound (string id, string desc) {
-            Canberra.Context context;
-            Canberra.Proplist props;
-
-            Canberra.Context.create (out context);
-            Canberra.Proplist.create (out props);
-
-            props.sets (Canberra.PROP_EVENT_ID, id);
-            props.sets (Canberra.PROP_EVENT_DESCRIPTION, desc);
-            props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "permanent");
-
-            context.play_full (0, props, null);
         }
 
         private string get_tmp_filename () {


### PR DESCRIPTION
We currently rely on Screenshot to play the shutter sound. This means that it needs pulseaudio permissions in Flatpak and depending on the app taking the screenshot you might not get a sound when a screenshot is taken.

In addition, no sound was played when a screenshot was copied directly to the clipboard.

Play the shutter sound in Gala to avoid this problems.

**This PR:** Don't play the shutter after taking a screenshot, Gala will do it for us.

Fix https://github.com/elementary/gala/issues/944
Needs https://github.com/elementary/screenshot/pull/215
Needs https://github.com/elementary/gala/pull/1171