### PR TITLE
postinst: Explicitly use AppCenter remote

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,7 +3,7 @@
 set -e
 
 flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
-flatpak install --system --noninteractive io.elementary.screenshot//stable || true
+flatpak install --system --noninteractive appcenter io.elementary.screenshot//stable || true
 
 #DEBHELPER#
 


### PR DESCRIPTION
This will succeed without being explicit, but I feel like we should be explicit so we're (more) sure we're installing from the right remote, just in case there was a name conflict from another remote.