### PR TITLE
SaveDialog: use fileinfo, localize, DRY

### DIFF
--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -28,7 +28,6 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
     private Gtk.Label folder_name;
     private Gtk.Image folder_image;
-    private string folder_dir;
 
     public SaveDialog (Gdk.Pixbuf pixbuf, Settings settings, Gtk.Window parent) {
         Object (
@@ -43,7 +42,7 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
     construct {
         set_keep_above (true);
-        folder_dir = Environment.get_user_special_dir (UserDirectory.PICTURES)
+        var folder_dir = Environment.get_user_special_dir (UserDirectory.PICTURES)
             + "%c".printf (GLib.Path.DIR_SEPARATOR) + Application.SAVE_FOLDER;
 
         var folder_from_settings = settings.get_string ("folder-dir");
@@ -159,7 +158,7 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
         folder_image = new Gtk.Image ();
 
-        update_location_button ();
+        update_location_button (folder_dir);
 
         var arrow = new Gtk.Image.from_icon_name ("view-more-horizontal-symbolic", BUTTON);
 
@@ -249,12 +248,12 @@ public class Screenshot.SaveDialog : Granite.Dialog {
                     folder_dir = settings.get_string ("folder-dir");
                 }
 
-                update_location_button ();
+                update_location_button (folder_dir);
             }
         });
     }
 
-    private void update_location_button () {
+    private void update_location_button (string folder_dir) {
         var file = File.new_for_path  (folder_dir);
         try {
             var info = file.query_info (

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -254,7 +254,7 @@ public class Screenshot.SaveDialog : Granite.Dialog {
     }
 
     private void update_location_button (string folder_dir) {
-        var file = File.new_for_path  (folder_dir);
+        var file = File.new_for_path (folder_dir);
         try {
             var info = file.query_info (
                 FileAttribute.STANDARD_DISPLAY_NAME + "," + FileAttribute.STANDARD_ICON,

--- a/src/Widgets/SaveDialog.vala
+++ b/src/Widgets/SaveDialog.vala
@@ -26,6 +26,10 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
     public signal void save_response (bool response, string folder_dir, string output_name, string format);
 
+    private Gtk.Label folder_name;
+    private Gtk.Image folder_image;
+    private string folder_dir;
+
     public SaveDialog (Gdk.Pixbuf pixbuf, Settings settings, Gtk.Window parent) {
         Object (
             deletable: false,
@@ -39,7 +43,7 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
     construct {
         set_keep_above (true);
-        var folder_dir = Environment.get_user_special_dir (UserDirectory.PICTURES)
+        folder_dir = Environment.get_user_special_dir (UserDirectory.PICTURES)
             + "%c".printf (GLib.Path.DIR_SEPARATOR) + Application.SAVE_FOLDER;
 
         var folder_from_settings = settings.get_string ("folder-dir");
@@ -148,41 +152,33 @@ public class Screenshot.SaveDialog : Granite.Dialog {
             margin_top = 18
         };
 
-        var folder_name = new Gtk.Label ("") {
+        folder_name = new Gtk.Label ("") {
             halign = Gtk.Align.START,
             hexpand = true
         };
 
-        var folder_icon = new Gtk.Image () {
-            pixel_size = 16
-        };
+        folder_image = new Gtk.Image ();
 
-        if (folder_dir == Environment.get_home_dir ()) {
-            folder_name.label = "Home";
-            folder_icon.gicon = new ThemedIcon ("user-home");
-        } else if (folder_dir == "/") {
-            folder_name.label = "File System";
-            folder_icon.gicon = new ThemedIcon ("drive-harddisk");
-        } else {
-            folder_name.label = Path.get_basename (folder_dir);
-            folder_icon.gicon = new ThemedIcon ("folder");
-        }
+        update_location_button ();
 
-        var arrow = new Gtk.Image () {
-            gicon = new ThemedIcon ("pan-down-symbolic"),
-            halign = Gtk.Align.END
-        };
+        var arrow = new Gtk.Image.from_icon_name ("view-more-horizontal-symbolic", BUTTON);
 
-        var location_button_indicator = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        location_button_indicator.add (folder_icon);
+        var location_button_indicator = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 3);
+        location_button_indicator.add (folder_image);
         location_button_indicator.add (folder_name);
         location_button_indicator.add (arrow);
 
-        var location_button = new Gtk.Button ();
-        location_button.add (location_button_indicator);
+        var location_button = new Gtk.Button () {
+            child = location_button_indicator
+        };
 
-        var location_dialog = new Gtk.FileChooserNative (_("Select Screenshots Folder…"), this,
-            Gtk.FileChooserAction.SELECT_FOLDER, "Open", "Cancel");
+        var location_dialog = new Gtk.FileChooserNative (
+            _("Select Screenshots Folder…"),
+            this,
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            _("Select"),
+            null
+        );
         location_dialog.set_current_folder (folder_dir);
 
         var content = this.get_content_area () as Gtk.Box;
@@ -253,17 +249,23 @@ public class Screenshot.SaveDialog : Granite.Dialog {
                     folder_dir = settings.get_string ("folder-dir");
                 }
 
-                if (folder_dir == Environment.get_home_dir ()) {
-                    folder_name.label = "Home";
-                    folder_icon.gicon = new ThemedIcon ("user-home");
-                } else if (folder_dir == "/") {
-                    folder_name.label = "File System";
-                    folder_icon.gicon = new ThemedIcon ("drive-harddisk");
-                } else {
-                    folder_name.label = Path.get_basename (folder_dir);
-                    folder_icon.gicon = new ThemedIcon ("folder");
-                }
+                update_location_button ();
             }
         });
+    }
+
+    private void update_location_button () {
+        var file = File.new_for_path  (folder_dir);
+        try {
+            var info = file.query_info (
+                FileAttribute.STANDARD_DISPLAY_NAME + "," + FileAttribute.STANDARD_ICON,
+                FileQueryInfoFlags.NONE
+            );
+            folder_name.label = info.get_display_name ();
+            folder_image.gicon = info.get_icon ();
+        } catch (Error e) {
+            folder_name.label = folder_dir;
+            folder_image.gicon = new ThemedIcon ("folder");
+        }
     }
 }


### PR DESCRIPTION
Follow up to #243 

* DRY updating location button
* Use the ellipsis icon and add some spacing
* Use build in translation for Cancel button, translate Select button
* Use FileInfo to get icon and display name for path