### PR TITLE
Application: use startup, builtin icon loading

### DIFF
--- a/data/gresource.xml
+++ b/data/gresource.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/io/elementary/screenshot">
-    <file alias="grab-area-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-area-symbolic.svg</file>
-    <file alias="grab-screen-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic.svg</file>
-    <file alias="grab-screen-symbolic-dark.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic-dark.svg</file>
-    <file alias="grab-window-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-window-symbolic.svg</file>
+  <gresource prefix="/io/elementary/screenshot/icons">
+    <file alias="32x32/actions/grab-area-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-area-symbolic.svg</file>
+    <file alias="32x32@2/actions/grab-area-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-area-symbolic.svg</file>
+    <file alias="32x32/actions/grab-screen-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic.svg</file>
+    <file alias="32x32@2/actions/grab-screen-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic.svg</file>
+    <file alias="32x32/actions/grab-screen-symbolic-dark.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic-dark.svg</file>
+    <file alias="32x32@2/actions/grab-screen-symbolic-dark.svg" compressed="true" preprocess="xml-stripblanks">grab-screen-symbolic-dark.svg</file>
+    <file alias="32x32/actions/grab-window-symbolic.svg" compressed="true" preprocess="xml-stripblanks">grab-window-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -69,6 +69,8 @@ public class Screenshot.Application : Gtk.Application {
     protected override void startup () {
         base.startup ();
 
+        Hdy.init ();
+
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -66,19 +66,28 @@ public class Screenshot.Application : Gtk.Application {
         add_main_option_entries (OPTION_ENTRIES);
     }
 
-    protected override void activate () {
-        weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
-        default_theme.add_resource_path ("/io/elementary/screenshot");
+    protected override void startup () {
+        base.startup ();
 
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();
 
-        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+        gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
 
         granite_settings.notify["prefers-color-scheme"].connect (() => {
-            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+            gtk_settings.gtk_application_prefer_dark_theme = granite_settings.prefers_color_scheme == DARK;
         });
 
+        var quit_action = new SimpleAction ("quit", null);
+        quit_action.activate.connect (() => {
+            quit ();
+        });
+
+        add_action (quit_action);
+        set_accels_for_action ("app.quit", {"<Control>q", "Escape"});
+    }
+
+    protected override void activate () {
         var action = 0;
         if (screen) action = 1;
         if (win) action = 2;
@@ -97,16 +106,6 @@ public class Screenshot.Application : Gtk.Application {
             window.set_application (this);
             window.take_clicked ();
         }
-
-        var quit_action = new SimpleAction ("quit", null);
-        quit_action.activate.connect (() => {
-            if (window != null) {
-                window.destroy ();
-            }
-        });
-
-        add_action (quit_action);
-        set_accels_for_action ("app.quit", {"<Control>q", "Escape"});
     }
 
     public static void create_dir_if_missing (string path) {

--- a/src/ScreenshotWindow.vala
+++ b/src/ScreenshotWindow.vala
@@ -70,8 +70,6 @@ public class Screenshot.ScreenshotWindow : Hdy.ApplicationWindow {
             return;
         }
 
-        Hdy.init ();
-
         set_keep_above (true);
         stick ();
 


### PR DESCRIPTION
* Use startup for actions and dark style instead of doing it every time we activate
* Use built-in icon loading by setting resource path instead of doing it manually
* Add paths for icons so they work correctly in GTK 4 while here