### PR TITLE
patch: fix screenshot crashing when image height exceeds width enough

### DIFF
--- a/src/SaveDialog.vala
+++ b/src/SaveDialog.vala
@@ -161,6 +161,7 @@ public class Screenshot.SaveDialog : Granite.Dialog {
 
         // Prevent large dialog size with large screenshots
         default_width = 500;
+        default_height = 500;
 
         var content = this.get_content_area () as Gtk.Box;
         content.append (dialog_label);


### PR DESCRIPTION
Closes #316.

## Description

This addresses the issue discussed in issue #316. To summarize what is in that issue, when taking a screenshot and the height is 1/4x or more greater than the width (approx), it will segfault with my setup.

Two solutions were found, but the simplest was in this PR, which is setting a default window height. The other was to use a deprecated method (which is shown in the issue).

As proof of the fix, here is a screenshot whose dimensions will crash the pre-fix app:

<img width="377" height="609" alt="image" src="https://github.com/user-attachments/assets/82987fd3-48f2-412e-a1cb-35732e6cdc74" />
